### PR TITLE
Improved release workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -11,21 +11,6 @@ on:
         required: true
 
 jobs:
-  make-release:
-    runs-on: ubuntu-latest
-    name: Create Release
-    steps:
-      - uses: actions/checkout@v4
-        if: github.event_name == 'push'
-      - uses: actions/checkout@v4
-        if: github.event_name == 'workflow_dispatch'
-        with:
-          ref: refs/tags/${{ github.event.inputs.tag }}
-
-      - uses: ghalactic/github-release-from-tag@v5
-        with:
-          summaryEnabled: false
-
   publish-image:
     name: Build and Push to Docker Hub
     runs-on: ubuntu-latest
@@ -36,6 +21,13 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         with:
           ref: refs/tags/${{ github.event.inputs.tag }}
+
+      - run: |
+          echo REPOSITORY="$(
+            echo "${GITHUB_REPOSITORY}" |
+              tr '[:upper:]' '[:lower:]' |
+              sed 's/docker-//'
+          )" >"${GITHUB_ENV}"
 
       - uses: docker/login-action@v3.0.0
         with:
@@ -52,8 +44,8 @@ jobs:
         uses: docker/metadata-action@v5.5.1
         with:
           images: |
-            kineticcafe/ansible
-            ghcr.io/kineticcafe/ansible
+            ${{ env.REPOSITORY }}
+            ghcr.io/${{ env.REPOSITORY }}
           # generate Docker tags based on the following events/attributes
           tags: |
             type=schedule
@@ -65,7 +57,7 @@ jobs:
             type=sha
 
       - uses: docker/setup-qemu-action@v3.0.0
-      - uses: docker/setup-buildx-action@v3.0.0
+      - uses: docker/setup-buildx-action@v3.1.0
 
       - id: docker_build
         uses: docker/build-push-action@v5.1.0
@@ -74,15 +66,20 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
           platforms: |
             linux/amd64
             linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - uses: ghalactic/github-release-from-tag@v5
+        with:
+          summaryEnabled: false
+
       - uses: peter-evans/dockerhub-description@v4.0.0
         with:
-          repository: kineticcafe/ansible
+          repository: kineticcafe/${{ env.REPOSITORY }}
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 


### PR DESCRIPTION
We maintain three docker images:

- ansible
- sqitch / pgTAP
- aws-cli with SessionManager plugin

The release flows are basically the same, but there were *unnecessary*
differences.

- We now no longer conditionally create the release in parallel to the
  image build and push. This would result in orphan releases if the
  build failed. The release creation is done at the end, immediately before
  updating the Dockerhub description.

- We add `annotations` to all metadata configuration.

- We set `env.REPOSITORY` based on `GITHUB_REPOSITORY`, converting entirely to
  lowercase and removing the leading `docker-`.

- We use `kineticcafe/${{ env.REPOSITORY }}` for image builds and Dockerhub
  description updates.